### PR TITLE
Update URLs to use site.baseurl

### DIFF
--- a/_includes/footer/footer-en.html
+++ b/_includes/footer/footer-en.html
@@ -1,11 +1,11 @@
-<a id="top" href="#"><img src="/images/arrow.png"></a>
+<a id="top" href="#"><img src="{{ site.baseurl }}/images/arrow.png"></a>
 
 <footer>
 
 <div id="f_container">
 	
 		<div id="f_1">
-			<div class="f_icon" style="background-image: url(/images/inforound.png);">
+			<div class="f_icon" style="background-image: url({{ site.baseurl }}/images/inforound.png);">
 			</div>
 			<div class="f_link_group bold">
 				<span class="f_link">&nbsp;<i class="fa fa-chevron-circle-right f_mini" aria-hidden="true"></i>&nbsp;&nbsp;<a href="https://projects.eclipse.org/projects/technology.omr">OMR on Eclipse Technology projects</a>
@@ -17,7 +17,7 @@
 		</div>
 		
 		<div id="f_1">
-			<div class="f_icon"  style="background-image: url(/images/GitHub-Mark-64px.png);">
+			<div class="f_icon"  style="background-image: url({{ site.baseurl }}/images/GitHub-Mark-64px.png);">
 			</div>
 			<div class="f_link_group bold">
 				<span class="f_link"><i class="fa fa-github-alt f_mini" aria-hidden="true"></i>&nbsp;&nbsp;<a href="https://github.com/eclipse/omr">Contribute on GitHub</a>
@@ -29,7 +29,7 @@
 		</div>
 
 		<div id="f_1">
-			<div class="f_icon"  style="background-image: url(/images/fa_thumb_up.png);">
+			<div class="f_icon"  style="background-image: url({{ site.baseurl }}/images/fa_thumb_up.png);">
 			</div>
 			<div class="f_link_group bold">
 				<span class="f_link"><i class="fa fa-twitter f_mini" aria-hidden="true"></i>&nbsp;&nbsp;<a href="https://twitter.com/eclipseomr">Follow us on Twitter</a>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,16 +4,16 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="/css/style.css">
-    <link rel="stylesheet" href="/css/dropit.css">
-    <link rel="stylesheet" href="/css/prism.css">
-    <link rel="stylesheet" href="/css/font-awesome.min.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/style.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/dropit.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/prism.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/font-awesome.min.css">
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&amp;amp;subset=latin,latin-ext">
 	<link href='https://fonts.googleapis.com/css?family=Roboto:700,300,500,400,100' rel='stylesheet' type='text/css'>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <script data-cfasync="false" src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-    <script data-cfasync="false" src="/js/app.js"></script>
-    <script data-cfasync="false" src="/js/retina.js"></script>
-    <script data-cfasync="false" src="/js/dropit.js"></script>
-    <script data-cfasync="false" src="/js/prism.js"></script>
+    <script data-cfasync="false" src="{{ site.baseurl }}/js/app.js"></script>
+    <script data-cfasync="false" src="{{ site.baseurl }}/js/retina.js"></script>
+    <script data-cfasync="false" src="{{ site.baseurl }}/js/dropit.js"></script>
+    <script data-cfasync="false" src="{{ site.baseurl }}/js/prism.js"></script>
 </head>

--- a/_includes/header/header-en.html
+++ b/_includes/header/header-en.html
@@ -2,23 +2,23 @@
   <div id="mobile-menu">
       <div id="nav-button" class="fa fa-bars fa-2x button"></div>
   </div>
-  <section id="logo"><a href="/" class="omr">Eclipse OMR</a>
+  <section id="logo"><a href="{{ site.baseurl }}/" class="omr">Eclipse OMR</a>
   </section>
   <div id="navbar">
       <ul id="navmenu">
-          <li><a href="/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Home</a></li>
+          <li><a href="{{ site.baseurl }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Home</a></li>
           <li>
               <ul id="getting-started-menu" class="menu">
-                  <li><a href="/starter/whatisomr.html"{% if page.menu == 'starter' %} class="active"{% endif %}>Getting started</a>
+                  <li><a href="{{ site.baseurl }}/starter/whatisomr.html"{% if page.menu == 'starter' %} class="active"{% endif %}>Getting started</a>
                       <ul>
                           <li>
-                            <a href="/starter/whatisomr.html">What is OMR?</a>
+                            <a href="{{ site.baseurl }}/starter/whatisomr.html">What is OMR?</a>
                           </li>
                           <li>
-                            <a href="/starter/goals.html">Project goals</a>
+                            <a href="{{ site.baseurl }}/starter/goals.html">Project goals</a>
                           </li>
                           <li>
-                          <a href="/starter/project.html">Get involved</a>
+                          <a href="{{ site.baseurl }}/starter/project.html">Get involved</a>
                           </li>
                      </ul>
                   </li>
@@ -26,19 +26,19 @@
           </li>
           <li>
               <ul id="guide-menu" class="menu">
-                  <li><a href="/guide/building.html"{% if page.menu == 'guide' %} class="active"{% endif %}>Guide</a>
+                  <li><a href="{{ site.baseurl }}/guide/building.html"{% if page.menu == 'guide' %} class="active"{% endif %}>Guide</a>
                       <ul>
-                          <li><a href="/guide/building.html">Building</a>
+                          <li><a href="{{ site.baseurl }}/guide/building.html">Building</a>
                           </li>
-                          <li><a href="/guide/configuring.html">Configuring</a>
+                          <li><a href="{{ site.baseurl }}/guide/configuring.html">Configuring</a>
                           </li>
-                          <li><a href="/guide/testing.html">Testing your runtime</a>
+                          <li><a href="{{ site.baseurl }}/guide/testing.html">Testing your runtime</a>
                           </li>
-                          <li><a href="/guide/troubleshooting.html">Troubleshooting</a>
+                          <li><a href="{{ site.baseurl }}/guide/troubleshooting.html">Troubleshooting</a>
                           </li>
-                          <li><a href="/guide/best-practices.html">Best practices</a>
+                          <li><a href="{{ site.baseurl }}/guide/best-practices.html">Best practices</a>
                           </li>
-                          <li><a href="/guide/coding-stds.html">Coding standards</a>
+                          <li><a href="{{ site.baseurl }}/guide/coding-stds.html">Coding standards</a>
                           </li>
                       </ul>
                   </li>
@@ -46,27 +46,27 @@
           </li>
           <li>
               <ul id="reference-menu" class="menu">
-                  <li><a href="/reference/architecture.html"{% if page.menu == 'reference' %} class="active"{% endif %}>Reference</a>
+                  <li><a href="{{ site.baseurl }}/reference/architecture.html"{% if page.menu == 'reference' %} class="active"{% endif %}>Reference</a>
                       <ul>
-                          <li><a href="/reference/architecture.html">Architecture</a>
+                          <li><a href="{{ site.baseurl }}/reference/architecture.html">Architecture</a>
                           </li>
-                          <li><a href="/reference/components.html">Components:</a>
+                          <li><a href="{{ site.baseurl }}/reference/components.html">Components:</a>
                           </li>
-						  <li><a class="subsub" href="/reference/thread.html">Thread</a>
+						  <li><a class="subsub" href="{{ site.baseurl }}/reference/thread.html">Thread</a>
                           </li>
-                          <li><a class="subsub" href="/reference/gc.html">GC</a>
+                          <li><a class="subsub" href="{{ site.baseurl }}/reference/gc.html">GC</a>
                           </li>
-						  <li><a class="subsub" href="/reference/vm.html">VM</a>
+						  <li><a class="subsub" href="{{ site.baseurl }}/reference/vm.html">VM</a>
                           </li>
-                          <li><a class="subsub" href="/reference/jit.html">JIT</a>
+                          <li><a class="subsub" href="{{ site.baseurl }}/reference/jit.html">JIT</a>
                           </li>
-						  <li><a class="subsub" href="/reference/port.html">Port</a>
+						  <li><a class="subsub" href="{{ site.baseurl }}/reference/port.html">Port</a>
                           </li>
-                          <li><a class="subsub" href="/reference/tools.html">Tools</a>
+                          <li><a class="subsub" href="{{ site.baseurl }}/reference/tools.html">Tools</a>
                           </li>
-						  <li><a class="subsub" href="/reference/glue.html">Glue</a>
+						  <li><a class="subsub" href="{{ site.baseurl }}/reference/glue.html">Glue</a>
                           </li>
-						  <li><a class="subsub" href="/reference/util.html">Util</a>
+						  <li><a class="subsub" href="{{ site.baseurl }}/reference/util.html">Util</a>
                           </li>
                       </ul>
                   </li>
@@ -74,13 +74,13 @@
           </li>
           <li>
               <ul id="resources-menu" class="menu">
-                  <li><a href="/resources/omr-on-github.html"{% if page.menu == 'resources' %} class="active"{% endif %}>Resources</a>
+                  <li><a href="{{ site.baseurl }}/resources/omr-on-github.html"{% if page.menu == 'resources' %} class="active"{% endif %}>Resources</a>
                       <ul>
-                          <li><a href="/resources/omr-on-github.html">OMR on GitHub</a>
+                          <li><a href="{{ site.baseurl }}/resources/omr-on-github.html">OMR on GitHub</a>
                           </li>
-                          <li><a href="/resources/presentations.html">Presentations</a>
+                          <li><a href="{{ site.baseurl }}/resources/presentations.html">Presentations</a>
                           </li>
-                          <li><a href="/resources/blogs.html">Blogs</a>
+                          <li><a href="{{ site.baseurl }}/resources/blogs.html">Blogs</a>
                           </li>
                       </ul>
                   </li>
@@ -88,9 +88,9 @@
           </li>
 		  <li>
               <ul id="releases-menu" class="menu">
-                  <li><a href="/releases/first-release.html"{% if page.menu == 'releases' %} class="active"{% endif %}>Releases</a>
+                  <li><a href="{{ site.baseurl }}/releases/first-release.html"{% if page.menu == 'releases' %} class="active"{% endif %}>Releases</a>
                       <ul>
-                          <li><a href="/releases/first-release.html">What's new</a>
+                          <li><a href="{{ site.baseurl }}/releases/first-release.html">What's new</a>
                           </li>
                       </ul>
                   </li>
@@ -100,7 +100,7 @@
 		<div id="eggContainer">
 		<div align="center">
 			<a href="https://projects.eclipse.org/projects/technology.omr" style="padding-right: 0px;">
-				<img id="incubatingIcon" align="center" src="../../images/incubating.png" border="0" alt="Incubation" />
+				<img id="incubatingIcon" align="center" src="{{ site.baseurl }}/images/incubating.png" border="0" alt="Incubation" />
 			</a>
 		</div>
 		<h6 id="incubateText">Incubation</h6>

--- a/_layouts/header/header-en.html
+++ b/_layouts/header/header-en.html
@@ -2,23 +2,23 @@
   <div id="mobile-menu">
       <div id="nav-button" class="fa fa-bars fa-2x button"></div>
   </div>
-  <section id="logo"><a href="/" class="omr">OMR Toolkit</a>
+  <section id="logo"><a href="{{ site.baseurl }}/" class="omr">OMR Toolkit</a>
   </section>
   <div id="navbar">
       <ul id="navmenu">
-          <li><a href="/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Home</a></li>
+          <li><a href="{{ site.baseurl }}/" id="home-menu"{% if page.menu == 'home' %} class="active"{% endif %}>Home</a></li>
           <li>
               <ul id="getting-started-menu" class="menu">
-                  <li><a href="/starter/whatisomr.html"{% if page.menu == 'starter' %} class="active"{% endif %}>Getting started</a>
+                  <li><a href="{{ site.baseurl }}/starter/whatisomr.html"{% if page.menu == 'starter' %} class="active"{% endif %}>Getting started</a>
                       <ul>
                           <li>
-                            <a href="/starter/whatisomr.html">What is OMR?</a>
+                            <a href="{{ site.baseurl }}/starter/whatisomr.html">What is OMR?</a>
                           </li>
                           <li>
-                            <a href="/starter/goals.html">Project goals</a>
+                            <a href="{{ site.baseurl }}/starter/goals.html">Project goals</a>
                           </li>
                           <li>
-                          <a href="/starter/project.html">Working with the project</a>
+                          <a href="{{ site.baseurl }}/starter/project.html">Working with the project</a>
                           </li>
                      </ul>
                   </li>
@@ -26,19 +26,19 @@
           </li>
           <li>
               <ul id="guide-menu" class="menu">
-                  <li><a href="/guide/building.html"{% if page.menu == 'guide' %} class="active"{% endif %}>Guide</a>
+                  <li><a href="{{ site.baseurl }}/guide/building.html"{% if page.menu == 'guide' %} class="active"{% endif %}>Guide</a>
                       <ul>
-                          <li><a href="/guide/building.html">Building</a>
+                          <li><a href="{{ site.baseurl }}/guide/building.html">Building</a>
                           </li>
-                          <li><a href="/guide/configuring.html">Configuring</a>
+                          <li><a href="{{ site.baseurl }}/guide/configuring.html">Configuring</a>
                           </li>
-                          <li><a href="/guide/testing.html">Testing your runtime</a>
+                          <li><a href="{{ site.baseurl }}/guide/testing.html">Testing your runtime</a>
                           </li>
-                          <li><a href="/guide/troubleshooting.html">Troubleshooting</a>
+                          <li><a href="{{ site.baseurl }}/guide/troubleshooting.html">Troubleshooting</a>
                           </li>
-                          <li><a href="/guide/best-practices.html">Best practices</a>
+                          <li><a href="{{ site.baseurl }}/guide/best-practices.html">Best practices</a>
                           </li>
-                          <li><a href="/guide/coding-stds.html">Coding standards</a>
+                          <li><a href="{{ site.baseurl }}/guide/coding-stds.html">Coding standards</a>
                           </li>
                       </ul>
                   </li>
@@ -46,13 +46,13 @@
           </li>
           <li>
               <ul id="reference-menu" class="menu">
-                  <li><a href="/reference/architecture.html"{% if page.menu == 'reference' %} class="active"{% endif %}>Reference</a>
+                  <li><a href="{{ site.baseurl }}/reference/architecture.html"{% if page.menu == 'reference' %} class="active"{% endif %}>Reference</a>
                       <ul>
-                          <li><a href="/reference/architecture.html">Architecture</a>
+                          <li><a href="{{ site.baseurl }}/reference/architecture.html">Architecture</a>
                           </li>
-                          <li><a href="/reference/components.html">Components</a>
+                          <li><a href="{{ site.baseurl }}/reference/components.html">Components</a>
                           </li>
-                          <li><a href="/reference/port.html">Port</a>
+                          <li><a href="{{ site.baseurl }}/reference/port.html">Port</a>
                           </li>
                       </ul>
                   </li>
@@ -60,15 +60,15 @@
           </li>
           <li>
               <ul id="resources-menu" class="menu">
-                  <li><a href="/resources/omr-on-github.html"{% if page.menu == 'resources' %} class="active"{% endif %}>Resources</a>
+                  <li><a href="{{ site.baseurl }}/resources/omr-on-github.html"{% if page.menu == 'resources' %} class="active"{% endif %}>Resources</a>
                       <ul>
-                          <li><a href="/resources/omr-on-github.html">OMR on GitHub</a>
+                          <li><a href="{{ site.baseurl }}/resources/omr-on-github.html">OMR on GitHub</a>
                           </li>
-                          <li><a href="/resources/presentations.html">Presentations</a>
+                          <li><a href="{{ site.baseurl }}/resources/presentations.html">Presentations</a>
                           </li>
-                          <li><a href="/resources/whitepapers.html">Whitepapers</a>
+                          <li><a href="{{ site.baseurl }}/resources/whitepapers.html">Whitepapers</a>
                           </li>
-                          <li><a href="/resources/blogs.html">Blogs</a>
+                          <li><a href="{{ site.baseurl }}/resources/blogs.html">Blogs</a>
                           </li>
                       </ul>
                   </li>
@@ -76,9 +76,9 @@
           </li>
 		  <li>
               <ul id="releases-menu" class="menu">
-                  <li><a href="/releases/first-release.html"{% if page.menu == 'releases' %} class="active"{% endif %}>Releases</a>
+                  <li><a href="{{ site.baseurl }}/releases/first-release.html"{% if page.menu == 'releases' %} class="active"{% endif %}>Releases</a>
                       <ul>
-                          <li><a href="/releases/first-release.html">What's new</a>
+                          <li><a href="{{ site.baseurl }}/releases/first-release.html">What's new</a>
                           </li>
                       </ul>
                   </li>

--- a/index.md
+++ b/index.md
@@ -30,7 +30,7 @@ lang: en
 	<section>
 		<div>
 			<a class="centerAlign">
-				<img id="homeimg" src="/images/omrLogo1.png" />
+				<img id="homeimg" src="{{ site.baseurl }}/images/omrLogo1.png" />
 			</a>
 		</div>
 	</section>


### PR DESCRIPTION
The web site is not rendering correctly on github pages or
eclipse.org/omr because it is missing the site.baseurl

Signed-off-by: Charlie Gracie charlie.gracie@gmail.com
