### PR TITLE
Organize the presentations page, add content and update links

### DIFF
--- a/resources/presentations.md
+++ b/resources/presentations.md
@@ -27,13 +27,14 @@ lang: en
 
 - [*Highly Surmountable Challenges in Ruby+OMR JIT Compilation*](https://fosdem.org/2017/schedule/event/ruby_highly_surmountable_challenges_in_ruby_omr_jit_compilation/) Matthew Gaudet, FOSDEM, February 2017.
 - [*A different Lua JIT using Eclipse OMR*](https://fosdem.org/2017/schedule/event/eclipse_omr/) Charlie Gracie, FOSDEM, February 2017.
+- [*OMR B9*](https://github.com/youngar/Base9/blob/master/CUSEC%202017%20-%20Buildering%20a%20JIT.pdf) Andrew Young, Kim Briggs, Shelley Lambert and John Duimovich, CUSEC, January 2017.
 - [*Ruby and OMR: Experiments in utilizing OMR technologies in MRI*](http://bofh.nikhef.nl/events/FOSDEM/2016/h2213/ruby-and-omr.mp4) Charlie Gracie, FOSDEM, February 2016.
 
 # Deep Dives
 
 - [*Testing Testarossa - The Eclipse OMR Compiler*](https://youtu.be/D0BCftV6DpE) Leonardo Banderali, August, 2017.
-- [*How does Eclipse OMR compare to LLVM*](http://www.ustream.tv/recorded/105013815) Mark Stoodley, June, 2017.
-- [*Eclipse OMR Update Tech Talk*](http://www.ustream.tv/recorded/98846650) Mark Stoodley, developerWorks Open, January 2017.
+- [*Eclipse OMR: How does all this compare to LLVM?*](http://www.ustream.tv/recorded/105013815) Mark Stoodley, June, 2017.
+- [*Eclipse OMR Update: compiler component, JitBuilder and proof of concepts*](http://www.ustream.tv/recorded/98846650) Mark Stoodley, developerWorks Open, January 2017.
 - [*Eclipse OMR Tech Talk*](https://developer.ibm.com/open/videos/eclipse-omr-tech-talk/) Mark Stoodley, developerWorks Open, July 2016.
 - [*OMR: A modern toolkit for building language runtimes*](http://www.slideshare.net/MarkStoodley/omr-a-modern-toolkit-for-building-language-runtimes) Mark Stoodley, EclipseCON, March 2016.
 - [*A JVMs Journey into Polyglot Runtimes*](https://t.co/efCKf6aCB4) Charlie Gracie, jFokus, February 2016.

--- a/resources/presentations.md
+++ b/resources/presentations.md
@@ -23,22 +23,24 @@ lang: en
 [//]: # "*    <First author> - initial implementation and documentation"
 [//]: # "*********************************************************************"
 
-# Recent presentations
+# Case Studies
 
 - [*Highly Surmountable Challenges in Ruby+OMR JIT Compilation*](https://fosdem.org/2017/schedule/event/ruby_highly_surmountable_challenges_in_ruby_omr_jit_compilation/) Matthew Gaudet, FOSDEM, February 2017.
 - [*A different Lua JIT using Eclipse OMR*](https://fosdem.org/2017/schedule/event/eclipse_omr/) Charlie Gracie, FOSDEM, February 2017.
-- [*Eclipse OMR Update Tech Talk*](https://developer.ibm.com/open/videos/eclipse-omr-update-tech-talk/) Mark Stoodley, developerWorks Open, January 2017.
+- [*Ruby and OMR: Experiments in utilizing OMR technologies in MRI*](http://bofh.nikhef.nl/events/FOSDEM/2016/h2213/ruby-and-omr.mp4) Charlie Gracie, FOSDEM, February 2016.
 
-# Previous presentations and events 
+# Deep Dives
 
-- [*Eclipse OMR Tech Talk.*](https://developer.ibm.com/open/videos/eclipse-omr-tech-talk/) Mark Stoodley, developerWorks Open, July 2016.
-- [*OMR: A modern toolkit for building language runtimes*](http://www.slideshare.net/MarkStoodley/omr-a-modern-toolkit-for-building-language-runtimes). Mark Stoodley, EclipseCON, March 2016.
-- [*A JVMs Journey into Polyglot Runtimes.*](https://t.co/efCKf6aCB4) Charlie Gracie, jFokus, February 2016.
-- [*Ruby and OMR: Experiments in utilizing OMR technologies in MRI.*](http://bofh.nikhef.nl/events/FOSDEM/2016/h2213/ruby-and-omr.mp4) Charlie Gracie, FOSDEM, February 2016.
-- [*Building Your Own Runtime.*](https://ibm.box.com/s/7xdg25we2ezmdjjbqdys30d7dl1iyo49) Angela Lin, Robert Young, Craig Lehmann, and Xiaoli Liang, CASCON Workshop, November 2015.
-- [*What's in an Object? Java Garbage Collection for the Polyglot.*](http://www.slideshare.net/charliegracie1/javaone-whats-in-an-object) Charlie Gracie, Java One, October 2015.
-- [*Beyond the Coffee Cup: Leveraging Java Runtime Technologies for the Polyglot.*](http://www.slideshare.net/0xdaryl/javaone-2015-con7547-beyond-the-coffee-cup-leveraging-java-runtime-technologies-for-polyglot?related=1) Daryl Maier, Java One, October 2015.
-- [*A VM is a VM is a VM: The Secret Path to High Performance Multi-Language Runtimes.*](https://www.youtube.com/watch?v=kOnyJurioyw) Mark Stoodley, JVM Languages Summit, August 2015.
+- [*Testing Testarossa - The Eclipse OMR Compiler*](https://youtu.be/D0BCftV6DpE) Leonardo Banderali, August, 2017.
+- [*How does Eclipse OMR compare to LLVM*](http://www.ustream.tv/recorded/105013815) Mark Stoodley, June, 2017.
+- [*Eclipse OMR Update Tech Talk*](http://www.ustream.tv/recorded/98846650) Mark Stoodley, developerWorks Open, January 2017.
+- [*Eclipse OMR Tech Talk*](https://developer.ibm.com/open/videos/eclipse-omr-tech-talk/) Mark Stoodley, developerWorks Open, July 2016.
+- [*OMR: A modern toolkit for building language runtimes*](http://www.slideshare.net/MarkStoodley/omr-a-modern-toolkit-for-building-language-runtimes) Mark Stoodley, EclipseCON, March 2016.
+- [*A JVMs Journey into Polyglot Runtimes*](https://t.co/efCKf6aCB4) Charlie Gracie, jFokus, February 2016.
+- [*Building Your Own Runtime*](https://ibm.box.com/s/7xdg25we2ezmdjjbqdys30d7dl1iyo49) Angela Lin, Robert Young, Craig Lehmann, and Xiaoli Liang, CASCON Workshop, November 2015.
+- [*What's in an Object? Java Garbage Collection for the Polyglot*](http://www.slideshare.net/charliegracie1/javaone-whats-in-an-object) Charlie Gracie, Java One, October 2015.
+- [*Beyond the Coffee Cup: Leveraging Java Runtime Technologies for the Polyglot*](http://www.slideshare.net/0xdaryl/javaone-2015-con7547-beyond-the-coffee-cup-leveraging-java-runtime-technologies-for-polyglot?related=1) Daryl Maier, Java One, October 2015.
+- [*A VM is a VM is a VM: The Secret Path to High Performance Multi-Language Runtimes*](https://www.youtube.com/watch?v=kOnyJurioyw) Mark Stoodley, JVM Languages Summit, August 2015.
 
 
 Note: Some slides have been modified since the original presentation to include the Eclipse OMR project name.


### PR DESCRIPTION
I have changed to division from recent/previous presentations to case studies/deep dives.
I think this is a better way to present the content.
I have added 2 recents talks by @mstoodle and @Leonardo2718
I have updated the broken links