### PR TITLE
Add GDPR privacy policy popup

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,4 +16,11 @@
     <script data-cfasync="false" src="{{ site.baseurl }}/js/retina.js"></script>
     <script data-cfasync="false" src="{{ site.baseurl }}/js/dropit.js"></script>
     <script data-cfasync="false" src="{{ site.baseurl }}/js/prism.js"></script>
+	<!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5WLCZXC');</script>
+<!-- End Google Tag Manager --> 
 </head>


### PR DESCRIPTION
To meet new guidelines from Eclipse,
all project websites must use the
standard Eclipse privacy policy popup.

Closes: #23

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>